### PR TITLE
Update Cardinality Type in Interface

### DIFF
--- a/lform.ts
+++ b/lform.ts
@@ -80,7 +80,7 @@ export interface FormItem {
 
 export interface Cardinality {
   min: number;
-  max: number;
+  max: number | "*";
 }
 
 export interface ItemAnswer {


### PR DESCRIPTION
Cardinality is exported as a string in the official lhc form builder. Even if its a number its represented as a string. For eg: "1". But now we add the maximum value as '*' also along with the integer. 